### PR TITLE
【Add】userモデル作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_one_attached :avatar
+end

--- a/db/migrate/20220123093522_create_users.rb
+++ b/db/migrate/20220123093522_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :uuid
+      t.string :line_user_id
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_23_092756) do
+ActiveRecord::Schema.define(version: 2022_01_23_093522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,14 @@ ActiveRecord::Schema.define(version: 2022_01_23_092756) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "uuid"
+    t.string "line_user_id"
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
Resolves #7 
論理削除については便利なヘルパーメソッドがあるparanoiaで追加できるので、
deleted_atカラムは不要とする。
実装上制約は後に追加