### PR TITLE
uuid作成機能実装

### DIFF
--- a/app/models/concerns/uuid_generator.rb
+++ b/app/models/concerns/uuid_generator.rb
@@ -1,0 +1,13 @@
+module UuidGenerator
+
+  def self.included(uuid)
+    uuid.before_create :generate_uuid
+  end
+
+  def generate_uuid
+    self.uuid = loop do
+      uuid = SecureRandom.uuid
+      break uuid unless self.class.exists?(uuid: uuid)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   has_one_attached :avatar
+
+  include UuidGenerator
 end

--- a/db/migrate/20220123093522_create_users.rb
+++ b/db/migrate/20220123093522_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
-      t.string :uuid
+      t.string :uuid, null: false, unique: true
       t.string :line_user_id, null: false, unique: true
       t.string :name
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2022_01_23_093522) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "uuid"
+    t.string "uuid", null: false
     t.string "line_user_id", null: false
     t.string "name"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
Resolves #13 
uuid自動生成機能を実装
現状の想定では複数モデルでuuidを生成するので、ロジックはモジュールに記述
uuidは重複の可能性がほぼ無いとのことだが、可能性としてゼロでは無いので、
念のためDBにバリデーションを記述し、uuidが重複しなくなるまで再生成を繰り返すループ処理で実装

uuidカラムに対するDBの制約追加