### PR TITLE
【Fix】ログイン後の招待リンクに遷移できない問題を修正

### DIFF
--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -9,9 +9,9 @@ class AffiliationsController < ApplicationController
       @affiliation = @circle.affiliations.new(circle_id: @circle.id, user_id: current_user.id)
       if !Affiliation.find_by(user_id: current_user.id, circle_id: @circle.id)
         @affiliation.save
-        redirect_to circle_path(@circle) #フラッシュメッセージ @circle.nameに参加しました
+        redirect_to circle_path(@circle) #flash @circle.nameに参加しました
       else
-        redirect_to circle_path(@circle) #フラッシュメッセージ すでにメンバーです
+        redirect_to circle_path(@circle) #flash すでにメンバーです
       end
     else
       redirect_to auth_at_provider_path(:provider => :line)

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -2,13 +2,17 @@ class AffiliationsController < ApplicationController
   def new; end
 
   def create
-    @circle = Circle.find(params[:circle_id])
-    @affiliation = @circle.affiliations.new(circle_id: @circle.id, user_id: current_user.id)
-    if !Affiliation.find_by(user_id: current_user.id, circle_id: @circle.id)
-      @affiliation.save
-      redirect_to circle_path(@circle) #フラッシュメッセージ @circle.nameに参加しました
+    if logged_in?
+      @circle = Circle.find(params[:circle_id])
+      @affiliation = @circle.affiliations.new(circle_id: @circle.id, user_id: current_user.id)
+      if !Affiliation.find_by(user_id: current_user.id, circle_id: @circle.id)
+        @affiliation.save
+        redirect_to circle_path(@circle) #フラッシュメッセージ @circle.nameに参加しました
+      else
+        redirect_to circle_path(@circle) #フラッシュメッセージ すでにメンバーです
+      end
     else
-      redirect_to circle_path(@circle) #フラッシュメッセージ すでにメンバーです
+      redirect_to auth_at_provider_path(:provider => :line)
     end
   end
 end

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -1,4 +1,6 @@
 class AffiliationsController < ApplicationController
+  skip_before_action :require_login
+
   def new; end
 
   def create

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
     provider = params[:provider]
     # binding.pry
     if @user = login_from(provider)
-      redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
+      redirect_to request.referer , :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)
@@ -17,9 +17,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
+        redirect_to request.referer, :notice => "Logged in from #{provider.titleize}!"
       rescue
-        redirect_back_or_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+        redirect_to request.referer, :alert => "Failed to login from #{provider.titleize}!"
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
     provider = params[:provider]
     # binding.pry
     if @user = login_from(provider)
-      redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
+      redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)
@@ -17,9 +17,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
+        redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
       rescue
-        redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+        redirect_back_or_to root_path, :alert => "Failed to login from #{provider.titleize}!"
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
     provider = params[:provider]
     # binding.pry
     if @user = login_from(provider)
-      redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
+      redirect_back_or_to(root_path, :notice => "Logged in from #{provider.titleize}!")
     else
       begin
         @user = create_from(provider)
@@ -17,9 +17,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
+        redirect_back_or_to(root_path, :notice => "Logged in from #{provider.titleize}!")
       rescue
-        redirect_back_or_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+        redirect_back_or_to(root_path, :alert => "Failed to login from #{provider.titleize}!")
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
     provider = params[:provider]
     # binding.pry
     if @user = login_from(provider)
-      redirect_to request.referer, :notice => "Logged in from #{provider.titleize}!"
+      redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)
@@ -17,9 +17,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_to request.referer, :notice => "Logged in from #{provider.titleize}!"
+        redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
       rescue
-        redirect_to request.referer, :alert => "Failed to login from #{provider.titleize}!"
+        redirect_back_or_to root_path, :alert => "Failed to login from #{provider.titleize}!"
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -8,7 +8,7 @@ class OauthsController < ApplicationController
   def callback
     provider = params[:provider]
     if @user = login_from(provider)
-      redirect_back_or_to(fallback_location, :notice => "Logged in from #{provider.titleize}!")
+      redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)
@@ -16,9 +16,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_back_or_to(fallback_location, :notice => "Logged in from #{provider.titleize}!")
+        redirect_back_or_to root_path, :notice => "Logged in from #{provider.titleize}!"
       rescue
-        redirect_back_or_to(fallback_location, :alert => "Failed to login from #{provider.titleize}!")
+        redirect_back_or_to root_path, :alert => "Failed to login from #{provider.titleize}!"
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,9 +7,8 @@ class OauthsController < ApplicationController
 
   def callback
     provider = params[:provider]
-    # binding.pry
     if @user = login_from(provider)
-      redirect_back_or_to(root_path, :notice => "Logged in from #{provider.titleize}!")
+      redirect_back_or_to(fallback_location, :notice => "Logged in from #{provider.titleize}!")
     else
       begin
         @user = create_from(provider)
@@ -17,9 +16,9 @@ class OauthsController < ApplicationController
 
         reset_session # protect from session fixation attack
         auto_login(@user)
-        redirect_back_or_to(root_path, :notice => "Logged in from #{provider.titleize}!")
+        redirect_back_or_to(fallback_location, :notice => "Logged in from #{provider.titleize}!")
       rescue
-        redirect_back_or_to(root_path, :alert => "Failed to login from #{provider.titleize}!")
+        redirect_back_or_to(fallback_location, :alert => "Failed to login from #{provider.titleize}!")
       end
     end
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -9,7 +9,7 @@ class OauthsController < ApplicationController
     provider = params[:provider]
     # binding.pry
     if @user = login_from(provider)
-      redirect_to request.referer , :notice => "Logged in from #{provider.titleize}!"
+      redirect_to request.referer, :notice => "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)


### PR DESCRIPTION
Redsolves #88 
LINEアプリでログインボタンを押すと、別のブラウザが起動してログインするのでredirect_back_or_toも起動しなかったの、
その場合は1度ログインしてから、再度招待リンクを踏んでもらう形で実装