### PR TITLE
【Fix】マイページ編集時にアバター画像がない時にデフォルト画像を保存する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
 
   include UuidGenerator
   before_create :default_avatar
+  before_update :default_avatar
 
   def default_avatar
     if !avatar.attached?


### PR DESCRIPTION
Resolves #153 
before_updateでデフォルト画像を保存するように修正