### PR TITLE
【Add】サークルイベント一覧ページで出欠状態を表示

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -4,5 +4,5 @@ class Attendance < ApplicationRecord
 
   validates :comment, length: { maximum: 65_535 }
 
-  enum state: { present: 0, absent: 1, undecided: 2 }
+  enum state: { present: 0, absent: 1, undecided: 2, no_exit: 3 }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,4 +8,12 @@ class Event < ApplicationRecord
   def attendance_answer?(current_user)
     self.attendances.pluck(:user_id).include?(current_user.id)
   end
+
+  def attendance_state(current_user)
+    if self.attendances.find_by(user_id: current_user.id)
+      self.attendances.find_by(user_id: current_user.id).state_i18n
+    else
+      Attendance.states_i18n['no_exit']
+    end
+  end
 end

--- a/app/views/events/_circle_event.html.slim
+++ b/app/views/events/_circle_event.html.slim
@@ -2,8 +2,10 @@
   div id="event-id-#{event.id}"
     = link_to circle_event_path(@circle, event)
       .bg-white.flex.p-2.space-x-2.items-center.shadow-xl.max-w-sm.rounded-md
-        .column
-          div.font-semibold.text-xl
+        .flex
+          .font-semibold.text-xl
             = event.name
+          #event-state.ml-3
+            = event.attendance_state(current_user)
           p.mt-1.text-black.text-sm.cursor-pointer.line-clamp-3
             = event.event_at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,4 @@ ja:
         present: 未定
         absent: 出席
         undecided: 欠席
+        no_exit: 未入力


### PR DESCRIPTION
Resolves #156 
イベントに出欠登録してない場合はモデルが存在していない。
そこで、enumにDBには保存されない値として、'未入力'を追加し、
出欠登録をしていない場合はモデルから直接'未入力'を表示するようにする。