### PR TITLE
【Fix】circle_createのリファクタリング

### DIFF
--- a/app/controllers/circles_controller.rb
+++ b/app/controllers/circles_controller.rb
@@ -12,7 +12,6 @@ class CirclesController < ApplicationController
   def create
     @circle = current_user.circles.new(circle_params)
     if @circle.save
-      Affiliation.create(user: current_user, circle: @circle, circle_state: 1)
       redirect_to circle_path(@circle), notice: 'サークルを設立しました'
     else
       render :new

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -14,6 +14,7 @@ class Circle < ApplicationRecord
   enum state: { unpublish: 0, publish: 1 }
 
   before_create :default_top_image
+  after_create :create_affilication
   before_update :default_top_image
 
   include UuidGenerator
@@ -22,5 +23,9 @@ class Circle < ApplicationRecord
     unless top_image.attached?
       top_image.attach(io: File.open('app/assets/images/default_top_image.jpg'), filename: 'default_top_image.jpg')
     end
+  end
+
+  def create_affilication
+    affiliations.create(user_id: user_id, circle_state: :admin)
   end
 end


### PR DESCRIPTION
Resolves #269 
https://github.com/shinji128/circle-manager/issues/268
現状、circle_controllersのdef create内で、circle設立と同時にaffiliation(所属サークル)がcreateされる。
コールバック(after_create)で記述する。